### PR TITLE
Minor fixes

### DIFF
--- a/cmake/doxygen.cmake
+++ b/cmake/doxygen.cmake
@@ -16,7 +16,7 @@ file(MAKE_DIRECTORY ${FAIL_DOC_OUTPUT})
 #        means, the path to your Fail* directory should not contain any blanks.
 
 configure_file(${PROJECT_SOURCE_DIR}/cmake/Doxyfile.in
-		${PROJECT_BINARY_DIR}/Doxyfile @ONLY}
+		${PROJECT_BINARY_DIR}/Doxyfile @ONLY
 )
 
 ## call make doc to generate documentation

--- a/simulators/bochs/iodev/vga.cc
+++ b/simulators/bochs/iodev/vga.cc
@@ -558,7 +558,7 @@ void bx_vga_c::determine_screen_dimensions(unsigned *piHeight, unsigned *piWidth
 {
   int ai[0x20];
   int i,h,v;
-  for (i = 0 ; i < 0x20 ; i++)
+  for (i = 0 ; i < 0x19 ; i++)
    ai[i] = BX_VGA_THIS s.CRTC.reg[i];
 
   h = (ai[1] + 1) * 8;


### PR DESCRIPTION
Remove superfluous closing brace which prohibited cmake from recognizing the @ONLY argument
Fix out-of-bounds array access in bochs (https://github.com/svn2github/bochs/commit/cedafbb987152b2076faa03fe2bffb08773ae8a1)
