### PR TITLE
Use bit masks instead of access widths

### DIFF
--- a/src/core/comm/DatabaseCampaignMessage.proto.in
+++ b/src/core/comm/DatabaseCampaignMessage.proto.in
@@ -15,8 +15,8 @@ message DatabaseCampaignMessage {
     // using generic InjectionPointMessage
     required uint32 injection_instr          = 4 [(sql_ignore) = true];
     optional uint32 injection_instr_absolute = 5 [(sql_ignore) = true];
-    required uint32 data_address             = 6 [(sql_ignore) = true];
-    required uint32 data_width               = 7 [(sql_ignore) = true];
+    required uint64 data_address             = 6 [(sql_ignore) = true];
+    required uint64 data_mask                = 7 [(sql_ignore) = true];
     required string variant                  = 8 [(sql_ignore) = true];
     required string benchmark                = 9 [(sql_ignore) = true];
 

--- a/src/core/cpn/DatabaseCampaign.cc
+++ b/src/core/cpn/DatabaseCampaign.cc
@@ -202,22 +202,23 @@ bool DatabaseCampaign::run_variant(Database::Variant variant) {
 	/* Gather jobs */
 	unsigned long experiment_count;
 	std::stringstream ss;
-	std::string sql_select = "SELECT p.id, p.injection_instr, p.injection_instr_absolute, p.data_address, p.data_width, t.instr1, t.instr2 ";
+	std::string sql_select = "SELECT p.id, p.injection_instr, p.injection_instr_absolute, p.data_address, (t.data_mask & p.data_mask), t.instr1, t.instr2 ";
 	ss << " FROM fsppilot p "
 	   << " JOIN trace t"
-	   << " ON t.variant_id = p.variant_id AND t.data_address = p.data_address AND t.instr2 = p.instr2"
+	   << " ON t.variant_id = p.variant_id AND t.data_address = p.data_address AND t.instr2 = p.instr2 AND (t.data_mask & p.data_mask)"
 	   << " WHERE p.fspmethod_id IN (SELECT id FROM fspmethod WHERE method LIKE '" << m_fspmethod << "')"
 	   << "	  AND p.variant_id = " << variant.id
 	   << " ORDER BY t.instr1"; // Smart-Hopping needs this ordering
 	std::string sql_body = ss.str();
 
 	/* Get the number of unfinished experiments */
-	MYSQL_RES *count = db->query(("SELECT COUNT(*) " + sql_body).c_str(), true);
+	MYSQL_RES *count = db->query(("SELECT COUNT(*) as injections " + sql_body).c_str(), true);
 	if (!count) {
 		exit(1);
 	}
 	MYSQL_ROW row = mysql_fetch_row(count);
 	experiment_count = strtoul(row[0], NULL, 10);
+
 
 
 	MYSQL_RES *pilots = db->query_stream ((sql_select + sql_body).c_str());
@@ -235,22 +236,24 @@ bool DatabaseCampaign::run_variant(Database::Variant variant) {
 	// calculating at trace instruction zero
 	ConcreteInjectionPoint ip;
 
-	unsigned expected_results = expected_number_of_results(variant.variant, variant.benchmark);
-
 	unsigned sent_pilots = 0, skipped_pilots = 0;
+    unsigned long long expected_injections = 0;
 	while ((row = mysql_fetch_row(pilots)) != 0) {
 		unsigned pilot_id        = strtoul(row[0], NULL, 10);
+		unsigned injection_instr = strtoul(row[1], NULL, 10);
+		uint64_t data_address    = strtoul(row[3], NULL, 10);
+		unsigned data_mask       = strtoul(row[4], NULL, 10);
+		unsigned instr1          = strtoul(row[5], NULL, 10);
+		unsigned instr2          = strtoul(row[6], NULL, 10);
+
+        unsigned expected_results = m_inject_bursts ? 1 : __builtin_popcount(data_mask);
 		if (existing_results_for_pilot(pilot_id) == expected_results) {
 			skipped_pilots++;
 			campaignmanager.skipJobs(1);
 			continue;
 		}
+        expected_injections += expected_results - existing_results_for_pilot(pilot_id);
 
-		unsigned injection_instr = strtoul(row[1], NULL, 10);
-		unsigned data_address    = strtoul(row[3], NULL, 10);
-		unsigned data_width      = strtoul(row[4], NULL, 10);
-		unsigned instr1          = strtoul(row[5], NULL, 10);
-		unsigned instr2          = strtoul(row[6], NULL, 10);
 
 		DatabaseCampaignMessage pilot;
 		pilot.set_pilot_id(pilot_id);
@@ -267,7 +270,7 @@ bool DatabaseCampaign::run_variant(Database::Variant variant) {
 			pilot.set_injection_instr_absolute(injection_instr_absolute);
 		}
 		pilot.set_data_address(data_address);
-		pilot.set_data_width(data_width);
+		pilot.set_data_mask(data_mask);
 		pilot.set_inject_bursts(m_inject_bursts);
 		pilot.set_register_injection_mode(m_register_injection_mode);
 
@@ -277,6 +280,7 @@ bool DatabaseCampaign::run_variant(Database::Variant variant) {
 			log_send << "pushed " << sent_pilots << " pilots into the queue" << std::endl;
 		}
 	}
+    log_send << "expecting " << expected_injections << " injections to take place." << std::endl;
 
 	if (*mysql_error(db->getHandle())) {
 		log_send << "MYSQL ERROR: " << mysql_error(db->getHandle()) << std::endl;
@@ -312,7 +316,7 @@ void DatabaseCampaign::load_completed_pilots(std::vector<Database::Variant> &var
 	log_send << "loading completed pilot IDs ..." << std::endl;
 
 	std::stringstream sql;
-	sql << "SELECT pilot_id, COUNT(*) FROM fsppilot p"
+	sql << "SELECT pilot_id, COUNT(*), bit_count(data_mask) FROM fsppilot p"
 	    << " JOIN " << db_connect.result_table() << " r ON r.pilot_id = p.id"
 	    << " WHERE variant_id in (" << variant_str.str() << ")"
 	    << "   AND fspmethod_id IN (SELECT id FROM fspmethod WHERE method LIKE '" << m_fspmethod << "')"
@@ -326,6 +330,7 @@ void DatabaseCampaign::load_completed_pilots(std::vector<Database::Variant> &var
 	while ((row = mysql_fetch_row(ids)) != 0) {
 		unsigned pilot_id     = strtoul(row[0], NULL, 10);
 		unsigned result_count = strtoul(row[1], NULL, 10);
+		unsigned inj_count    = strtoul(row[2], NULL, 10);
 #ifndef __puma
 		completed_pilots.add(
 			make_pair(

--- a/src/core/cpn/DatabaseCampaign.hpp
+++ b/src/core/cpn/DatabaseCampaign.hpp
@@ -60,15 +60,6 @@ public:
 	virtual bool run_variant(fail::Database::Variant);
 
 	/**
-	 * How many results have to are expected from each fsppilot. If
-	 * there are less result rows, the pilot will be again sent to the clients
-	 * @return \c exptected number of results
-	 */
-	virtual int expected_number_of_results(std::string variant, std::string benchmark) {
-		return (m_inject_bursts ? 1 : 8);
-	}
-
-	/**
 	 * Callback function that can be used to add command line options
 	 * to the campaign
 	 */

--- a/tools/analysis/resultbrowser/app/model.py
+++ b/tools/analysis/resultbrowser/app/model.py
@@ -63,7 +63,7 @@ def closeSession():
 '''Populate variant results for overview data'''
 def getVariants(cur, table):
     restbl = table.getDetails().getDBName()
-    cur.execute("""SELECT sum((t.time2 - t.time1 + 1) * width) AS total, resulttype,variant, v.id as variant_id, benchmark, details FROM variant v JOIN trace t ON v.id = t.variant_id JOIN fspgroup g ON g.variant_id = t.variant_id AND g.instr2 = t.instr2 AND g.data_address = t.data_address JOIN %s r ON r.pilot_id = g.pilot_id  JOIN fsppilot p ON r.pilot_id = p.id GROUP BY v.id, resulttype, details""" % (restbl)) # % is used here, as a tablename must not be quoted
+    cur.execute("""SELECT sum((t.time2 - t.time1 + 1)) AS total, resulttype,variant, v.id as variant_id, benchmark, details FROM variant v JOIN trace t ON v.id = t.variant_id JOIN fspgroup g ON g.variant_id = t.variant_id AND g.instr2 = t.instr2 AND g.data_address = t.data_address AND (g.data_mask & t.data_mask) JOIN %s r ON r.pilot_id = g.pilot_id  JOIN fsppilot p ON r.pilot_id = p.id GROUP BY v.id, resulttype, details""" % (restbl)) # % is used here, as a tablename must not be quoted
     res = cur.fetchall()
     rdic = {}
     # Build dict with variant id as key
@@ -143,7 +143,7 @@ def getCode(result_table, variant_id, resultlabel=None):
 
     # I especially like this one:
     select = "SELECT instr_address, opcode, disassemble, comment, sum(t.time2 - t.time1 + 1) as totals,  GROUP_CONCAT(DISTINCT resulttype SEPARATOR ', ') as results FROM variant v "
-    join   = "   JOIN trace t ON v.id = t.variant_id  JOIN fspgroup g ON g.variant_id = t.variant_id AND g.instr2 = t.instr2 AND g.data_address = t.data_address      JOIN %s r ON r.pilot_id = g.pilot_id  JOIN fsppilot p ON r.pilot_id = p.id JOIN objdump ON objdump.variant_id = v.id AND objdump.instr_address = injection_instr_absolute " %(scrub(result_table))
+    join   = "   JOIN trace t ON v.id = t.variant_id  JOIN fspgroup g ON g.variant_id = t.variant_id AND g.instr2 = t.instr2 AND g.data_address = t.data_address AND (g.data_mask & t.data_mask)   JOIN %s r ON r.pilot_id = g.pilot_id  JOIN fsppilot p ON r.pilot_id = p.id JOIN objdump ON objdump.variant_id = v.id AND objdump.instr_address = injection_instr_absolute " %(scrub(result_table))
     where  = "WHERE v.id = %s "
     group  = "GROUP BY injection_instr_absolute ORDER BY totals DESC "
 

--- a/tools/import-trace/Importer.cc
+++ b/tools/import-trace/Importer.cc
@@ -31,8 +31,8 @@ bool Importer::create_database() {
 		"	instr2_absolute int(10) unsigned DEFAULT NULL,"
 		"	time1 bigint(10) unsigned NOT NULL,"
 		"	time2 bigint(10) unsigned NOT NULL,"
-		"	data_address int(10) unsigned NOT NULL,"
-		"	width tinyint(3) unsigned NOT NULL,"
+		"	data_address bigint(10) unsigned NOT NULL,"
+		"	data_mask tinyint(3) unsigned NOT NULL,"
 		"	accesstype enum('R','W') NOT NULL,";
 	if (m_extended_trace) {
 		create_statement << "   data_value int(10) unsigned NULL,";
@@ -44,7 +44,7 @@ bool Importer::create_database() {
 	}
 	create_statement << database_additional_columns();
 	create_statement <<
-		"	PRIMARY KEY (variant_id,data_address,instr2)"
+		"	PRIMARY KEY (variant_id,data_address,instr2,data_mask)"
 		") engine=MyISAM ";
 	return db->query(create_statement.str().c_str());
 }
@@ -61,14 +61,24 @@ bool Importer::clear_database() {
 
 bool Importer::sanitycheck(std::string check_name, std::string fail_msg, std::string sql)
 {
-	LOG << "Sanity check: " << check_name << " ..." << std::flush;
+	LOG << "Sanity check: " << check_name << " ..." << std::flush << std::endl;
 	MYSQL_RES *res = db->query(sql.c_str(), true);
 
 	if (res && mysql_num_rows(res) == 0) {
-		std::cout << " OK" << std::endl;
+		LOG << " OK" << std::endl;
 		return true;
 	} else {
-		std::cout << " FAILED: " << fail_msg << std::endl;
+		LOG << " FAILED: " <<  std::endl << fail_msg << std::endl;
+		LOG << " ERROR MSG: " << std::endl;
+		MYSQL_ROW row;
+		int num_fields = mysql_num_fields(res);
+		while((row = mysql_fetch_row(res))) {
+			std::stringstream this_row;
+			for(int i = 0; i < num_fields;  ++i) {
+				this_row << " " << row[i];
+			}
+			LOG << this_row.str() << std::endl;
+		}
 		return false;
 	}
 }
@@ -169,12 +179,12 @@ bool Importer::copy_to_database(fail::ProtoIStream &ps) {
 
 		// non-overlapping (instr1/2)?
 		ss <<
-			"SELECT t1.variant_id\n"
+			"SELECT t1.variant_id,HEX(t1.data_address),t1.instr1,t1.instr2\n"
 			"FROM trace t1\n"
 			"JOIN variant v\n"
 			"  ON v.id = t1.variant_id\n"
 			"JOIN trace t2\n"
-			"  ON t1.variant_id = t2.variant_id AND t1.data_address = t2.data_address\n"
+			"  ON t1.variant_id = t2.variant_id AND t1.data_address = t2.data_address AND t1.data_mask = t2.data_mask\n"
 			" AND (t1.instr1 != t2.instr1 OR t2.instr2 != t2.instr2)\n"
 			" AND ((t1.instr1 >= t2.instr1 AND t1.instr1 <= t2.instr2)\n"
 			"  OR (t1.instr2 >= t2.instr1 AND t1.instr2 <= t2.instr2)\n"
@@ -188,12 +198,12 @@ bool Importer::copy_to_database(fail::ProtoIStream &ps) {
 
 		// non-overlapping (time1/2)?
 		ss <<
-			"SELECT t1.variant_id\n"
+			"SELECT t1.variant_id, HEX(t1.data_address), t1.instr1, t1.instr2\n"
 			"FROM trace t1\n"
 			"JOIN variant v\n"
 			"  ON v.id = t1.variant_id\n"
 			"JOIN trace t2\n"
-			"  ON t1.variant_id = t2.variant_id AND t1.data_address = t2.data_address\n"
+			"  ON t1.variant_id = t2.variant_id AND t1.data_address = t2.data_address AND t1.data_mask = t2.data_mask\n"
 			" AND (t1.time1 != t2.time1 OR t2.time2 != t2.time2)\n"
 			" AND ((t1.time1 >= t2.time1 AND t1.time1 <= t2.time2)\n"
 			"  OR (t1.time2 >= t2.time1 AND t1.time2 <= t2.time2)\n"
@@ -207,18 +217,18 @@ bool Importer::copy_to_database(fail::ProtoIStream &ps) {
 
 		// covered (instr1/2)?
 		ss <<
-			"SELECT t.variant_id, t.data_address,\n"
+			"SELECT t.variant_id, HEX(t.data_address),\n"
 			" (SELECT (MAX(t2.instr2) - MIN(t2.instr1) + 1)\n"
 			"  FROM trace t2\n"
 			"  WHERE t2.variant_id = t.variant_id)\n"
 			" -\n"
 			" (SELECT SUM(t3.instr2 - t3.instr1 + 1)\n"
 			"  FROM trace t3\n"
-			"  WHERE t3.variant_id = t.variant_id AND t3.data_address = t.data_address)\n"
+			"  WHERE t3.variant_id = t.variant_id AND t3.data_address = t.data_address AND t3.data_mask = t.data_mask)\n"
 			" AS diff\n"
 			"FROM trace t\n"
 			"WHERE t.variant_id = " << m_variant_id << "\n"
-			"GROUP BY t.variant_id, t.data_address\n"
+			"GROUP BY t.variant_id, t.data_address,t.data_mask\n"
 			"HAVING diff != 0\n"
 			"ORDER BY t.data_address\n";
 		if (!sanitycheck("FS row sum = total width (instr1/2)",
@@ -237,11 +247,11 @@ bool Importer::copy_to_database(fail::ProtoIStream &ps) {
 			" -\n"
 			" (SELECT SUM(t3.time2 - t3.time1 + 1)\n"
 			"  FROM trace t3\n"
-			"  WHERE t3.variant_id = t.variant_id AND t3.data_address = t.data_address)\n"
+			"  WHERE t3.variant_id = t.variant_id AND t3.data_address = t.data_address AND t3.data_mask = t.data_mask)\n"
 			" AS diff\n"
 			"FROM trace t\n"
 			"WHERE t.variant_id = " << m_variant_id << "\n"
-			"GROUP BY t.variant_id, t.data_address\n"
+			"GROUP BY t.variant_id, t.data_address, t.data_mask\n"
 			"HAVING diff != 0\n"
 			"ORDER BY t.data_address\n";
 		if (!sanitycheck("FS row sum = total width (time1/2)",
@@ -263,7 +273,7 @@ bool Importer::copy_to_database(fail::ProtoIStream &ps) {
 			" (SELECT data_address, MIN(instr1) AS min_instr, MAX(instr2) AS max_instr\n"
 			"  FROM trace t3\n"
 			"  WHERE variant_id = " << m_variant_id << "\n"
-			"  GROUP BY t3.variant_id, t3.data_address) AS local\n"
+			"  GROUP BY t3.variant_id, t3.data_address, t3.data_mask) AS local\n"
 			" ON (local.min_instr != global.min_instr\n"
 			"  OR local.max_instr != global.max_instr)";
 		if (!sanitycheck("Global min/max = FS row local min/max (instr1/2)",
@@ -285,7 +295,7 @@ bool Importer::copy_to_database(fail::ProtoIStream &ps) {
 			" (SELECT data_address, MIN(time1) AS min_time, MAX(time2) AS max_time\n"
 			"  FROM trace t3\n"
 			"  WHERE variant_id = " << m_variant_id << "\n"
-			"  GROUP BY t3.variant_id, t3.data_address) AS local\n"
+			"  GROUP BY t3.variant_id, t3.data_address,t3.data_mask) AS local\n"
 			" ON (local.min_time != global.min_time\n"
 			"  OR local.max_time != global.max_time)";
 		if (!sanitycheck("Global min/max = FS row local min/max (time1/2)",
@@ -314,7 +324,7 @@ bool Importer::add_trace_event(margin_info_t &begin, margin_info_t &end,
 }
 
 bool Importer::add_trace_event(margin_info_t &begin, margin_info_t &end,
-							   Trace_Event &event, bool is_fake) {
+							   Trace_Event &event, bool known_outcome) {
 	if (!m_import_write_ecs && event.accesstype() == event.WRITE) {
 		return true;
 	}
@@ -336,7 +346,7 @@ bool Importer::add_trace_event(margin_info_t &begin, margin_info_t &end,
 	if (!insert_sql->size()) {
 		std::stringstream sql;
 		sql << "INSERT INTO trace (variant_id, instr1, instr1_absolute, instr2, instr2_absolute, time1, time2, "
-		       "data_address, width, accesstype";
+			   "data_address, data_mask, accesstype";
 		*columns = 10;
 		if (extended) {
 			sql << ", data_value";
@@ -376,18 +386,19 @@ bool Importer::add_trace_event(margin_info_t &begin, margin_info_t &end,
 
 	unsigned data_address = event.memaddr();
 	char accesstype = event.accesstype() == event.READ ? 'R' : 'W';
+	unsigned data_mask = 255;
 
 	std::stringstream value_sql;
 	value_sql << "("
 		<< m_variant_id << ","
 		<< begin.dyninstr << ",";
-	if (begin.ip == 0 || is_fake) {
+	if (begin.ip == 0 || known_outcome) {
 		value_sql << "NULL,";
 	} else {
 		value_sql << begin.ip << ",";
 	}
 	value_sql << end.dyninstr << ",";
-	if (end.ip == 0 || is_fake) {
+	if (end.ip == 0 || known_outcome) {
 		value_sql << "NULL,";
 	} else {
 		value_sql << end.ip << ",";
@@ -395,7 +406,7 @@ bool Importer::add_trace_event(margin_info_t &begin, margin_info_t &end,
 	value_sql << begin.time << ","
 		<< end.time << ","
 		<< data_address << ","
-		<< "1," // width
+		<< data_mask << ","
 		<< "'" << accesstype << "',";
 
 	if (extended) {
@@ -424,7 +435,7 @@ bool Importer::add_trace_event(margin_info_t &begin, margin_info_t &end,
 
 	// Ask specialized importers what concrete data they want to INSERT.
 	if (num_additional_columns &&
-		!database_insert_data(event, value_sql, num_additional_columns, is_fake)) {
+		!database_insert_data(event, value_sql, num_additional_columns, known_outcome)) {
 		return false;
 	}
 

--- a/tools/prune-trace/FESamplingPruner.cc
+++ b/tools/prune-trace/FESamplingPruner.cc
@@ -155,7 +155,7 @@ bool FESamplingPruner::sampling_prune(const fail::Database::Variant& variant)
 	if (!m_use_known_results) {
 		// FIXME: change strategy when trace entries have IDs, insert into fspgroup first
 		ss << "INSERT INTO fsppilot (known_outcome, variant_id, instr2, injection_instr, "
-			<< "injection_instr_absolute, data_address, data_width, fspmethod_id) VALUES ";
+			<< "injection_instr_absolute, data_address, data_mask, fspmethod_id) VALUES ";
 		std::string insert_sql(ss.str());
 		ss.str("");
 
@@ -164,7 +164,7 @@ bool FESamplingPruner::sampling_prune(const fail::Database::Variant& variant)
 			Pilot p = pop.remove(pos);
 			ss << "(0," << variant.id << "," << p.instr2 << "," << p.instr2
 				<< "," << p.instr2_absolute << "," << p.data_address
-				<< ",1," << m_method_id << ")";
+				<< ",255," << m_method_id << ")";
 			db->insert_multiple(insert_sql.c_str(), ss.str().c_str());
 			ss.str("");
 		}
@@ -173,9 +173,9 @@ bool FESamplingPruner::sampling_prune(const fail::Database::Variant& variant)
 		uint64_t num_fsppilot_entries = samplerows;
 
 		// single entry for known outcome (write access)
-		ss << "INSERT INTO fsppilot (known_outcome, variant_id, instr2, injection_instr, injection_instr_absolute, data_address, data_width, fspmethod_id) "
+		ss << "INSERT INTO fsppilot (known_outcome, variant_id, instr2, injection_instr, injection_instr_absolute, data_address, data_mask, fspmethod_id) "
 			  "SELECT 1, variant_id, instr2, instr2, instr2_absolute, "
-			  "  data_address, width, " << m_method_id << " "
+			  "  data_address, data_mask, " << m_method_id << " "
 			  "FROM trace "
 			  "WHERE variant_id = " << variant.id << " AND accesstype = 'W' "
 			  "ORDER BY instr2 ASC "

--- a/tools/prune-trace/Pruner.cc
+++ b/tools/prune-trace/Pruner.cc
@@ -85,11 +85,11 @@ bool Pruner::create_database() {
 	    "  instr2 int(10) unsigned NOT NULL,"
 	    "  injection_instr int(10) unsigned NOT NULL,"
 	    "  injection_instr_absolute int(10) unsigned,"
-	    "  data_address int(10) unsigned NOT NULL,"
-	    "  data_width int(10) unsigned NOT NULL,"
+	    "  data_address bigint(10) unsigned NOT NULL,"
+	    "  data_mask tinyint(3) unsigned NOT NULL,"
 	    "  fspmethod_id int(11) NOT NULL,"
 	    "  PRIMARY KEY (id),"
-	    "  KEY fspmethod_id (fspmethod_id,variant_id,data_address,instr2)"
+	    "  KEY fspmethod_id (fspmethod_id,variant_id,data_address,instr2,data_mask)"
 	    ") engine=MyISAM ";
 	bool success = (bool) db->query(create_statement.c_str());
 	if (!success) return false;
@@ -97,11 +97,12 @@ bool Pruner::create_database() {
 	create_statement = "CREATE TABLE IF NOT EXISTS fspgroup ("
 	    "  variant_id      int(11) NOT NULL,"
 	    "  instr2          int(11) unsigned NOT NULL,"
-	    "  data_address    int(10) unsigned NOT NULL,"
+	    "  data_address    bigint(10) unsigned NOT NULL,"
+        "  data_mask       tinyint(3) unsigned NOT NULL,"
 	    "  fspmethod_id    int(11) NOT NULL,"
 	    "  pilot_id        int(11) NOT NULL,"
 	    "  weight int(11) UNSIGNED,"
-	    "  PRIMARY KEY (variant_id, data_address, instr2, fspmethod_id),"
+	    "  PRIMARY KEY (variant_id, data_address, instr2, data_mask, fspmethod_id),"
 	    "  KEY joinresults (pilot_id,fspmethod_id)) engine=MyISAM";
 
 	return db->query(create_statement.c_str());

--- a/tools/tests/export-injection
+++ b/tools/tests/export-injection
@@ -16,6 +16,7 @@ join fspgroup g
     on  t.variant_id = g.variant_id
     and t.instr2 = g.instr2
     and t.data_address = g.data_address
+    and (t.data_mask & g.data_mask)
 join fsppilot p
     on  t.variant_id = p.variant_id
     and g.fspmethod_id = p.fspmethod_id

--- a/tools/tests/run
+++ b/tools/tests/run
@@ -118,16 +118,21 @@ def import_trace():
 
 
       # Infer the number of fault locations
-      result = mysql(f"""SELECT DISTINCT data_address, width
+      result = mysql(f"""SELECT DISTINCT data_address, data_mask
                         FROM trace t
                         JOIN variant v ON v.id = t.variant_id 
                         WHERE v.variant = "{args.benchmark}" and v.benchmark = "{location}" 
                       """)
       bits = set()
       for r in result:
-         for offset in range(0, int(r['width'])):
-            for bit in range(0, 8):
-               bits.add((int(r['data_address']) + offset, bit))
+         mask = int(r['data_mask'])
+         i = 0
+         while (1 << i) <= mask:
+            if not ((1 << i) & mask): continue
+            offset = i // 8
+            bit    = i % 8
+            bits.add((int(r['data_address']) + offset, bit))
+            i += 1
 
       logging.info(f"{len(bits)} fault locations ({location})")
 
@@ -136,7 +141,7 @@ def import_trace():
          assert len(bits) == int(trace_pb_stats["#memLocations"]) * 8,\
             "Number of fault locations (memory) is not equal to dump-trace"
 
-      result = mysql(f"""SELECT sum((t.time2 - t.time1 + 1) * width * 8) as fault_space_size
+      result = mysql(f"""SELECT sum((t.time2 - t.time1 + 1) * bit_count(data_mask)) as fault_space_size
                         FROM trace t
                         JOIN variant v ON v.id = t.variant_id 
                         WHERE v.variant = "{args.benchmark}" and v.benchmark = "{location}" 
@@ -163,7 +168,7 @@ def basic_pruner():
       check_output(cmd)
 
       # Is every trace event covered by a fsppilot?
-      sql = f"""SELECT p.id is null as no_pilot, count(*) as intervals, sum((t.time2 - t.time1 + 1) * t.width * 8) as area,
+      sql = f"""SELECT p.id is null as no_pilot, count(*) as intervals, sum((t.time2 - t.time1 + 1) * bit_count(t.data_mask)) as area,
                        count(distinct p.id) as pilots
          FROM trace t
          LEFT OUTER JOIN fspgroup g
@@ -192,6 +197,7 @@ def basic_pruner():
               on  t.variant_id = g.variant_id
               and t.instr2 = g.instr2
               and t.data_address = g.data_address
+              and (t.data_address & g.data_address)
           JOIN fsppilot p
               on  t.variant_id = p.variant_id
               and g.fspmethod_id = p.fspmethod_id


### PR DESCRIPTION
With this *breaking* change, FAIL* does no longer use widths of data
accesses in its database schema, but bit masks. Thereby it is possible
to prevent or focus on the injection of individual bits.

For this change, the following database tables use masks with the
following meanings:

- trace.data_mask:    given bits were accessed
- fspgroup.data_mask: complete or partial match of a trace-table
                      entries data-mask
- fsppilot.data_mask: given bits are to be injected with this pilot

In order to reflect these database changes, you should
add (fspgroup.data_mask & trace.data_mask) to your join between trace
and fspgroup table to record for a cardinalty mismatch between both
tables. However, for the basic pruner (def-use pruner), this is not
necessary, as the data mask is in both cases 255.

Co-authored: Christian Dietrich <dietrich@sra.uni-hannover.de>